### PR TITLE
HA: ASG Lifecycle Hooks + Warm Pool

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -5,10 +5,12 @@ data "aws_ec2_instance_type" "this" {
 data "aws_ami" "this" {
   most_recent = true
   owners      = var.ami_owners
+
   filter {
     name   = "architecture"
     values = data.aws_ec2_instance_type.this.supported_architectures
   }
+
   filter {
     name   = "name"
     values = [var.ami_name_filter]
@@ -20,6 +22,7 @@ data "aws_ami" "this" {
 # see https://github.com/terraform-aws-modules/terraform-aws-eks/issues/1008#issuecomment-691182478
 data "aws_iam_policy_document" "this" {
   count = var.ha_enabled ? 1 : 0
+
   statement {
     effect = "Allow"
     actions = [

--- a/main.tf
+++ b/main.tf
@@ -168,7 +168,8 @@ resource "aws_autoscaling_group" "this" {
   min_size                  = 1
   max_size                  = 1
   desired_capacity          = 1
-  health_check_grace_period = 30
+  # set the health check grace period to 0 when using a lifecycle hook for instance launch
+  health_check_grace_period = var.ha.enabled ? 0 : 60
   default_cooldown          = 15
   health_check_type         = "EC2"
   vpc_zone_identifier       = [var.subnet_id]

--- a/main.tf
+++ b/main.tf
@@ -23,17 +23,22 @@ data "aws_iam_policy_document" "this" {
   statement {
     effect = "Allow"
     actions = [
+      "ec2:ReplaceRoute",
       "ec2:ModifyNetworkInterfaceAttribute",
-      "ec2:AttachNetworkInterface",
-      "ec2:DescribeNetworkInterfaces",
-      "ec2:DescribeNetworkInterfaceAttribute",
       "ec2:DetachNetworkInterface",
+      "ec2:DescribeNetworkInterfaceAttribute",
+      "ec2:DescribeNetworkInterfaces",
+      "ec2:AttachNetworkInterface",
       "autoscaling:DescribeLifecycleHookTypes",
-      "autoscaling:CompleteLifecycleAction",
+      "autoscaling:DescribeAutoScalingGroups",
       "autoscaling:DescribeAutoScalingInstances",
+      "autoscaling:CompleteLifecycleAction",
     ]
     # TODO improve access control to resources by the instance
     #      https://docs.aws.amazon.com/IAM/latest/UserGuide/access_iam-tags.html
+    # filter access by ec2:RouteTableID for ec2:ReplaceRoute, ec2:Vpc and ec2:ResourceTag/${TagKey}
+    # see https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonec2.html
+    # see https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonec2.html#amazonec2-policy-keys
     resources = ["*"]
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,3 @@
 output "network_interface_id" {
-  value = var.ha.enabled ? aws_network_interface.this[0].id : aws_instance.this[0].primary_network_interface_id
+  value = var.ha_enabled ? aws_network_interface.this[0].id : aws_instance.this[0].primary_network_interface_id
 }

--- a/user_data.sh
+++ b/user_data.sh
@@ -14,27 +14,12 @@ function get_token {
     echo $(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
 }
 
-function get_target_state {
-    echo $(curl -s -H "X-aws-ec2-metadata-token: $1" http://169.254.169.254/latest/meta-data/autoscaling/target-lifecycle-state)
-}
-
 function get_instance_id {
     echo $(curl -s -H "X-aws-ec2-metadata-token: $1" http://169.254.169.254/latest/meta-data/instance-id)
 }
 
 function get_region {
     echo $(curl -s -H "X-aws-ec2-metadata-token: $1" http://169.254.169.254/latest/meta-data/placement/region)
-}
-
-function get_ami_launch_index {
-    echo $(curl -s -H "X-aws-ec2-metadata-token: $1" http://169.254.169.254/latest/meta-data/ami-launch-index)
-}
-
-function get_network_attachment_id {
-    echo $(aws ec2 describe-network-interface-attribute --region $1 --network-interface-id $2 --attribute attachment \
-        | grep -E -i -o 'AttachmentId": "(eni-attach-[a-z0-9]+)"' \
-        | cut -f 2 -d ' ' \
-        | tr -d '"')
 }
 
 function get_asg_lifecycle_state {
@@ -53,6 +38,13 @@ function complete_lifecycle_action {
         --lifecycle-hook-name $3 \
         --instance-id $4 \
         --lifecycle-action-result $5
+}
+
+function get_network_attachment_id {
+    echo $(aws ec2 describe-network-interface-attribute --region $1 --network-interface-id $2 --attribute attachment \
+        | grep -E -i -o 'AttachmentId": "(eni-attach-[a-z0-9]+)"' \
+        | cut -f 2 -d ' ' \
+        | tr -d '"')
 }
 
 function detach_network_interface {

--- a/user_data.sh
+++ b/user_data.sh
@@ -4,8 +4,8 @@ echo "eni_id=${eni_id}" >> /etc/fck-nat.conf
 echo "asg_name=${asg_name}" >> /etc/fck-nat.conf
 echo "asg_hook_name=${asg_hook_name}" >> /etc/fck-nat.conf
 
-# add single quotes around EOF to prevent parameter/arithmetic expansion and command substitution
-cat >~/heal.sh <<'EOF'
+# use single quotes around EOF to prevent parameter/arithmetic expansion and command substitution
+cat >~/lifecycle.sh <<'EOF'
 #!/usr/bin/env bash
 
 . /etc/fck-nat.conf
@@ -30,6 +30,13 @@ function get_ami_launch_index {
     echo $(curl -s -H "X-aws-ec2-metadata-token: $1" http://169.254.169.254/latest/meta-data/ami-launch-index)
 }
 
+function get_network_attachment_id {
+    echo $(aws ec2 describe-network-interface-attribute --region $1 --network-interface-id $2 --attribute attachment \
+        | grep -E -i -o 'AttachmentId": "(eni-attach-[a-z0-9]+)"' \
+        | cut -f 2 -d ' ' \
+        | tr -d '"')
+}
+
 function get_asg_lifecycle_state {
     echo $(aws autoscaling describe-auto-scaling-instances \
         --region $1 \
@@ -39,81 +46,56 @@ function get_asg_lifecycle_state {
     | tr -d '"')
 }
 
+function complete_lifecycle_action {
+    aws autoscaling complete-lifecycle-action \
+        --region $1 \
+        --auto-scaling-group-name $2 \
+        --lifecycle-hook-name $3 \
+        --instance-id $4 \
+        --lifecycle-action-result $5
+}
+
+function detach_network_interface {
+    attachment_id=$(get_network_attachment_id $1 $2)
+    if [ -n "$attachment_id" ]; then
+        aws ec2 detach-network-interface \
+            --region $1 \
+            --attachment-id $attachment_id \
+            --force
+        # wait until network interface is completely detached
+        while [ -n "$attachment_id" ]; do
+            attachment_id=$(get_network_attachment_id $1 $2)
+            sleep 0.5
+        done
+    fi
+}
+
 token=$(get_token)
 region=$(get_region $token)
 instance_id=$(get_instance_id $token)
 lifecycle_state=$(get_asg_lifecycle_state $region $instance_id)
 
 # check for Pending:Wait lifecycle to start reattaching the network interface to this instance
-if [[ "$lifecycle_state" == "Pending:Wait" && ! -f ~/heal.lock ]]; then
-
-    touch ~/heal.lock
-
-    # get ENI attachment id
-    attachment_id=$(aws ec2 describe-network-interface-attribute \
-        --region $region \
-        --attribute attachment \
-        --network-interface-id $eni_id \
-        | grep -E -i -o 'AttachmentId": "(eni-attach-[a-z0-9]+)"' \
-        | cut -f 2 -d ' ' \
-        | tr -d '"')
-
-    # force detaching the ENI
-    if [ -n "$attachment_id" ]; then
-        aws ec2 detach-network-interface \
-            --region $region \
-            --attachment-id $attachment_id \
-            --force
-    fi
-
-    # complete asg lifecycle action so the instance can transition from 'Pending:Wait' to 'InService'
-    aws autoscaling complete-lifecycle-action \
-        --lifecycle-hook-name $asg_hook_name \
-        --auto-scaling-group-name $asg_name \
-        --lifecycle-action-result CONTINUE \
-        --instance-id $instance_id \
-        --region $region
-
-    # wait until network interface is completely detached
-    while [ -n "$attachment_id" ]; do
-        attachment_id=$(aws ec2 describe-network-interface-attribute \
-            --region $region \
-            --attribute attachment \
-            --network-interface-id $eni_id \
-            | grep -E -i -o 'AttachmentId": "(eni-attach-[a-z0-9]+)"' \
-            | cut -f 2 -d ' ' \
-            | tr -d '"')
-        sleep 0.5
-    done
-
-    # restart fck-nat so the ENI is attached to the instance and routes are configured properly
+if [[ "$lifecycle_state" == "Pending:Wait" && ! -f ~/lifecycle.lock ]]; then
+    touch ~/lifecycle.lock
+    detach_network_interface $region $eni_id
     /sbin/service fck-nat restart
-
     crontab -r
-
+    complete_lifecycle_action $region $asg_name $asg_hook_name $instance_id CONTINUE
 fi
 
 # check for Warmed:Pending:Wait lifecycle so the instance can transition to Warmed:Running
-if [[ "$lifecycle_state" == "Warmed:Pending:Wait" && ! -f ~/warmed.lock ]]; then
-
-    touch ~/warmed.lock
-
-    # complete asg lifecycle action so the instance can be added to the warmed pool
-    aws autoscaling complete-lifecycle-action \
-        --lifecycle-hook-name $asg_hook_name \
-        --auto-scaling-group-name $asg_name \
-        --lifecycle-action-result CONTINUE \
-        --instance-id $instance_id \
-        --region $region
-
+if [[ "$lifecycle_state" == "Warmed:Pending:Wait" && ! -f ~/lifecycle.warmed.lock ]]; then
+    touch ~/lifecycle.warmed.lock
+    complete_lifecycle_action $region $asg_name $asg_hook_name $instance_id CONTINUE
 fi
 
 EOF
 
-chmod +x ~/heal.sh
+chmod +x ~/lifecycle.sh
 
 # add crontab to check lifecycle state every 5 seconds
 crontab<<EOF
 $(crontab -l)
-* * * * * for i in {0..11}; do ~/heal.sh & sleep 5; done; touch ~/heal.sh
+* * * * * for i in {0..11}; do ~/lifecycle.sh & sleep 5; done; touch ~/lifecycle.sh
 EOF

--- a/user_data.sh
+++ b/user_data.sh
@@ -1,3 +1,119 @@
 #!/usr/bin/env bash
 
 echo "eni_id=${eni_id}" >> /etc/fck-nat.conf
+echo "asg_name=${asg_name}" >> /etc/fck-nat.conf
+echo "asg_hook_name=${asg_hook_name}" >> /etc/fck-nat.conf
+
+# add single quotes around EOF to prevent parameter/arithmetic expansion and command substitution
+cat >~/heal.sh <<'EOF'
+#!/usr/bin/env bash
+
+. /etc/fck-nat.conf
+
+function get_token {
+    echo $(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+}
+
+function get_target_state {
+    echo $(curl -s -H "X-aws-ec2-metadata-token: $1" http://169.254.169.254/latest/meta-data/autoscaling/target-lifecycle-state)
+}
+
+function get_instance_id {
+    echo $(curl -s -H "X-aws-ec2-metadata-token: $1" http://169.254.169.254/latest/meta-data/instance-id)
+}
+
+function get_region {
+    echo $(curl -s -H "X-aws-ec2-metadata-token: $1" http://169.254.169.254/latest/meta-data/placement/region)
+}
+
+function get_ami_launch_index {
+    echo $(curl -s -H "X-aws-ec2-metadata-token: $1" http://169.254.169.254/latest/meta-data/ami-launch-index)
+}
+
+function get_asg_lifecycle_state {
+    echo $(aws autoscaling describe-auto-scaling-instances \
+        --region $1 \
+        --instance-ids $2 \
+    | grep -E -i -o 'LifecycleState": "([A-Za-z:]+)"' \
+    | cut -f 2 -d ' ' \
+    | tr -d '"')
+}
+
+token=$(get_token)
+region=$(get_region $token)
+instance_id=$(get_instance_id $token)
+lifecycle_state=$(get_asg_lifecycle_state $region $instance_id)
+
+# check for Pending:Wait lifecycle to start reattaching the network interface to this instance
+if [[ "$lifecycle_state" == "Pending:Wait" && ! -f ~/heal.lock ]]; then
+
+    touch ~/heal.lock
+
+    # get ENI attachment id
+    attachment_id=$(aws ec2 describe-network-interface-attribute \
+        --region $region \
+        --attribute attachment \
+        --network-interface-id $eni_id \
+        | grep -E -i -o 'AttachmentId": "(eni-attach-[a-z0-9]+)"' \
+        | cut -f 2 -d ' ' \
+        | tr -d '"')
+
+    # force detaching the ENI
+    if [ -n "$attachment_id" ]; then
+        aws ec2 detach-network-interface \
+            --region $region \
+            --attachment-id $attachment_id \
+            --force
+    fi
+
+    # complete asg lifecycle action so the instance can transition from 'Pending:Wait' to 'InService'
+    aws autoscaling complete-lifecycle-action \
+        --lifecycle-hook-name $asg_hook_name \
+        --auto-scaling-group-name $asg_name \
+        --lifecycle-action-result CONTINUE \
+        --instance-id $instance_id \
+        --region $region
+
+    # wait until network interface is completely detached
+    while [ -n "$attachment_id" ]; do
+        attachment_id=$(aws ec2 describe-network-interface-attribute \
+            --region $region \
+            --attribute attachment \
+            --network-interface-id $eni_id \
+            | grep -E -i -o 'AttachmentId": "(eni-attach-[a-z0-9]+)"' \
+            | cut -f 2 -d ' ' \
+            | tr -d '"')
+        sleep 0.5
+    done
+
+    # restart fck-nat so the ENI is attached to the instance and routes are configured properly
+    /sbin/service fck-nat restart
+
+    crontab -r
+
+fi
+
+# check for Warmed:Pending:Wait lifecycle so the instance can transition to Warmed:Running
+if [[ "$lifecycle_state" == "Warmed:Pending:Wait" && ! -f ~/warmed.lock ]]; then
+
+    touch ~/warmed.lock
+
+    # complete asg lifecycle action so the instance can be added to the warmed pool
+    aws autoscaling complete-lifecycle-action \
+        --lifecycle-hook-name $asg_hook_name \
+        --auto-scaling-group-name $asg_name \
+        --lifecycle-action-result CONTINUE \
+        --instance-id $instance_id \
+        --region $region
+
+fi
+
+EOF
+
+chmod +x ~/heal.sh
+
+# add crontab to check lifecycle state every 5 seconds
+crontab<<EOF
+$(crontab -l)
+* * * * * for i in {0..11}; do ~/heal.sh & sleep 5; done; touch ~/heal.sh
+EOF

--- a/variables.tf
+++ b/variables.tf
@@ -6,9 +6,11 @@ variable "name" {
 variable "ha" {
   type = object({
     enabled = bool
+    warm_pool = number
   })
   default = {
     enabled = true
+    warm_pool = 0
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -3,15 +3,19 @@ variable "name" {
   default = "fck-nat-gateway"
 }
 
-variable "ha" {
-  type = object({
-    enabled = bool
-    warm_pool = number
-  })
-  default = {
-    enabled = true
-    warm_pool = 0
-  }
+variable "ha_enabled" {
+  type    = bool
+  default = true
+}
+
+variable "ha_warm_pool" {
+  type    = bool
+  default = false
+}
+
+variable "ha_route_table_id" {
+  type    = string
+  default = null
 }
 
 variable "instance_type" {


### PR DESCRIPTION
This PR introduces
- ASG lifecycle hooks on instance launch:
  - attach ENI on `Pending:Wait` and then transition to `InService`
  - attach backup ENI on `Warmed:Pending:Wait` and then transition to `Warmed:Running`
- ASG warm pool with 1 instance in `Running` state to reduce NAT Gateway downtime